### PR TITLE
csvrates binary

### DIFF
--- a/csvrates/Cargo.toml
+++ b/csvrates/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "csvrates"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+csv = "1.3.0"
+serde = { version = "1.0.210", features = ["derive"] }
+serde_json = "1.0.128"

--- a/csvrates/src/main.rs
+++ b/csvrates/src/main.rs
@@ -1,0 +1,92 @@
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::io::{BufRead, BufReader, Read};
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct NegotiatedPrices {
+    negotiated_rate: f64,
+}
+#[derive(Debug, Deserialize)]
+struct NegotiatedRates {
+    negotiated_prices: Vec<NegotiatedPrices>,
+}
+#[derive(Debug, Deserialize)]
+struct Record {
+    billing_code: String,
+    name: String,
+    negotiated_rates: Vec<NegotiatedRates>,
+}
+
+#[derive(serde::Serialize)]
+struct CsvRow<'a> {
+    name: &'a str,
+    billing_code: &'a str,
+    avg_rate: f64,
+}
+
+fn main() -> std::io::Result<()> {
+    let input = env::args().nth(1);
+    let output = env::args().nth(2);
+    match (input, output) {
+        (Some(filename), Some(outfile)) => process_lines(
+            fs::File::open(filename).expect("can open input file"),
+            fs::File::create(outfile).expect("can open output file"),
+        ),
+        (Some(filename), None) => process_lines(
+            fs::File::open(filename).expect("can open input file"),
+            std::io::stdout(),
+        ),
+        (_, _) => process_lines(std::io::stdin(), std::io::stdout()),
+    }
+}
+
+/// go through and read and write
+fn process_lines<R: Read, W: Write>(reader: R, writer: W) -> std::io::Result<()> {
+    let mut csv_writer = csv::Writer::from_writer(writer);
+    let buffer = BufReader::new(reader);
+    for line in buffer.lines() {
+        // this panics on a bad record, but we could use if let if we wanted to be less strict
+        let rec = serde_json::from_str::<Record>(&line.expect("line reading works"))
+            .expect("valid record json");
+        // note we skip
+        if let Some(average_negotiated_rate) = calc_average_negotiated_rate(&rec.negotiated_rates) {
+            if average_negotiated_rate > 30.0 {
+                continue;
+            }
+            let csv_row = create_csv_row(&rec, average_negotiated_rate);
+            csv_writer.serialize(csv_row)?
+        }
+    }
+    Ok(())
+}
+
+/// this outputs the csv line by line
+/// unfortunately this is coupled to the csv writer type (File vs io)
+fn create_csv_row(rec: &Record, average_negotiated_rate: f64) -> CsvRow {
+    CsvRow {
+        name: &rec.name,
+        billing_code: &rec.billing_code,
+        // note this is an f64, so not formatted to 2 decimal places
+        avg_rate: average_negotiated_rate,
+    }
+}
+
+// protects against missing rates, but not against negatives or other possible JSON oddities
+fn calc_average_negotiated_rate(negotiated_rates: &[NegotiatedRates]) -> Option<f64> {
+    let mut sum = 0.0;
+    let mut count_of_rates = 0.0;
+    for nr in negotiated_rates {
+        for np in nr.negotiated_prices.iter() {
+            sum += np.negotiated_rate;
+            count_of_rates += 1.0;
+        }
+    }
+    if count_of_rates > 0.0 {
+        Some(sum / count_of_rates)
+    } else {
+        None
+    }
+}

--- a/csvrates/src/main.rs
+++ b/csvrates/src/main.rs
@@ -27,6 +27,12 @@ struct CsvRow<'a> {
     avg_rate: f64,
 }
 
+// Notes:
+// could use clap here to do tighter arg parsing and give some help, as is it's
+// csvrates infile outfile
+// csvrates infile > stdout
+// or csvrates < stdin > stdout
+// also could use the anyhow crate to clean up some of the error handling.
 fn main() -> std::io::Result<()> {
     let input = env::args().nth(1);
     let output = env::args().nth(2);


### PR DESCRIPTION
This can be run with:
`cd csvrates; cargo run ../sample.jsonl outputfile_name.csv`

It should also work with stdin and stdout just fine.

Thanks, this was fun!